### PR TITLE
Removed imports that were never used

### DIFF
--- a/src/_pages/LandingPage/components/HeaderView/components/Astronaut/index.tsx
+++ b/src/_pages/LandingPage/components/HeaderView/components/Astronaut/index.tsx
@@ -1,5 +1,5 @@
 import { animated, useSpring } from 'react-spring';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useAgile } from '@agile-ts/react';
 import core from '../../../../../../core';
 import styles from './styles.module.css';

--- a/src/_pages/LandingPage/components/HeaderView/index.tsx
+++ b/src/_pages/LandingPage/components/HeaderView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import HeaderTyper from './components/HeaderTyper';
 import Spacer from '../../../../components/other/Spacer';

--- a/src/_pages/LandingPage/components/StartCodingView/components/LiveCoder/index.tsx
+++ b/src/_pages/LandingPage/components/StartCodingView/components/LiveCoder/index.tsx
@@ -8,7 +8,6 @@ import { FaReact, FaVuejs } from 'react-icons/all';
 import usePrismTheme from '@theme/hooks/usePrismTheme';
 import PlainButton from '../../../../../../components/buttons/PlainButton';
 import FrameworkButton from './components/FrameworkButton';
-import { useWindowSize } from '../../../../../../hooks/useWindowSize';
 
 type Props = {
   reactCode: string;

--- a/src/_pages/LandingPage/components/StatsView/components/StatBadge/index.tsx
+++ b/src/_pages/LandingPage/components/StatsView/components/StatBadge/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styles from './styles.module.css';
-import { IconContext } from 'react-icons';
 import Icons, { IconTypes } from '../../../../../../components/other/Icons';
 import clsx from 'clsx';
 import { useHistory } from 'react-router-dom';

--- a/src/_pages/LandingPage/index.tsx
+++ b/src/_pages/LandingPage/index.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { useWindowSize } from '../../hooks/useWindowSize';
-import Layout from '@theme/Layout';
 import styles from './styles.module.css';
 
 import 'react-toastify/dist/ReactToastify.css';

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface WindowSizeInterface {
   windowWidth: number;


### PR DESCRIPTION
- A few imports were returning `warning  'xxx' is defined but never used`. 

## 📄 Description

Removed imports that were imported but never used.

## 🔴 Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please provide a link to the issue here -->

## 📃 Context

Removes the lint warnings. Not necessarily errors.

## 🛠 How Has This Been Tested?

- Briefly tested on the browser manually.
※ As a site note; we should add some unit tests because non really exist
